### PR TITLE
Support ProfileID in TransactionSearch,  and add subscription search tests that use it.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ auth.txt
 blib
 perltidy.LOG
 pm_to_blib
+subscription-payment.html

--- a/auth.sample.3token
+++ b/auth.sample.3token
@@ -1,3 +1,4 @@
 Username  = test1_api.mydomain.tld
 Password  = XXXXXXXXXXXXXXXX
 Signature = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+SellerEmail = email-of-business-test-account@mydomain.tld

--- a/auth.sample.cert
+++ b/auth.sample.cert
@@ -2,3 +2,4 @@ Username = test1_api.mydomain.tld
 Password = myapipassword
 CertFile = /www/var/cert_key_pem.txt
 KeyFile  = /www/var/cert_key_pem.txt
+SellerEmail = email-of-business-test-account@mydomain.tld

--- a/lib/Business/PayPal/API/TransactionSearch.pm
+++ b/lib/Business/PayPal/API/TransactionSearch.pm
@@ -20,6 +20,7 @@ sub TransactionSearch {
         Payer            => 'ebl:EmailAddressType',
         Receiver         => 'ebl:EmailAddressType',
         ReceiptID        => 'xs:string',
+        ProfileID        => 'xs:string',
         TransactionID    => 'xs:string',
         InvoiceID        => 'xs:string',
         PayerName        => 'xs:string',

--- a/t/API.pl
+++ b/t/API.pl
@@ -26,7 +26,7 @@ sub do_args {
 
     my @variables = qw( Username Password Signature Subject timeout
         CertFile KeyFile PKCS12File PKCS12Password
-        BuyerEmail
+        BuyerEmail SellerEmail
     );
 
     my %patterns = ();

--- a/t/SubscriptionPayments.t
+++ b/t/SubscriptionPayments.t
@@ -2,6 +2,7 @@
 use Test::More;
 use strict;
 use autodie qw(:all);
+use Cwd;
 
 if ( !$ENV{WPP_TEST} || !-f $ENV{WPP_TEST} ) {
     plan skip_all =>
@@ -59,7 +60,7 @@ _SUBSCRIPTION_PAYMENT_DATA_
   ;
 close(SUBSCRIPTION_PAY_HTML);
 
-use Cwd; my $cwd = getcwd;
+my $cwd = getcwd;
 
 print STDERR <<"_PROFILEID_";
 Please note the next series of tests will not succeeed unless there is at

--- a/t/SubscriptionPayments.t
+++ b/t/SubscriptionPayments.t
@@ -79,8 +79,6 @@ my $ts   = new Business::PayPal::API::TransactionSearch( %args );
 
 my $resp = $ts->TransactionSearch(StartDate => $startdate);
 
-use Data::Dumper;
-
 ok(scalar @{$resp} > 0, "Some transactions found");
 
 my($profileID, %possibleTransactionIDs);

--- a/t/SubscriptionPayments.t
+++ b/t/SubscriptionPayments.t
@@ -1,0 +1,107 @@
+# -*- mode: cperl -*-
+use Test::More;
+use strict;
+if ( !$ENV{WPP_TEST} || !-f $ENV{WPP_TEST} ) {
+    plan skip_all =>
+        'No WPP_TEST env var set. Please see README to run tests';
+}
+else {
+    plan tests => 5;
+}
+
+use_ok( 'Business::PayPal::API::TransactionSearch' );
+#########################
+
+require 't/API.pl';
+
+my %args = do_args();
+
+=pod
+
+The following four tests shows the methodology to use TransactionSearch to
+find transactions that are part of the same ProfileID.  This method was
+discovered by trial-and-error.  Specifically, it's somewhat odd that
+TransactionSearch is used with the parameter of 'ProfileID' with the value
+set to a specific TransactionID to find the ProfileID via the "Created"
+transaction.  Then, in turn, that ProfileID can find the subscription payments
+related to the original transaction.
+
+This works, and seems to be correct, albeit odd.
+
+=cut
+
+open(SUBSCRIPTION_PAY_HTML, ">", "subscription-payment.html")
+  or die "unable to open subscription-payment.html: $!";
+print SUBSCRIPTION_PAY_HTML <<_SUBSCRIPTION_PAYMENT_DATA_
+<html>
+<body>
+<form action="https://www.sandbox.paypal.com/cgi-bin/webscr" method="post" target="_top">
+            <input type="hidden" name="business" value="$args{SellerEmail}" />
+            <input type="hidden" name="item_name" value="Monthly Payment" />
+            <input type="hidden" name="cmd" value="_xclick-subscriptions">
+            <input id="no_shipping" type="hidden" name="no_shipping" value="0" />
+            <input type="hidden" name="lc" value="US">
+            <input type="hidden" name="no_note" value="1">
+            <input type="hidden" name="t3" value="M" />
+            <input type="hidden" name="p3" value="1" />
+            <input type="hidden" name="src" value="1" />
+            <input type="hidden" name="srt" value="0" />
+            <input id="no_shipping" type="hidden" name="no_shipping" value="0" />
+            <input type="hidden" name="no_note" value="1">
+            <input id="amount" type="text" name="a3" size="5" minimum="10" value="10" />
+            <input type="image" border="0" name="submit" alt="Make test monthly payment now">
+</form>
+</body>
+</html>
+_SUBSCRIPTION_PAYMENT_DATA_
+  ;
+close(SUBSCRIPTION_PAY_HTML); die "unable to write subscription-payment.html: $!" if ($? != 0);
+
+use Cwd; my $cwd = getcwd;
+
+print STDERR <<"_PROFILEID_";
+Please note the next series of tests will not succeeed unless there is at
+least one transaction that is part of a subscription payments in your business
+account.
+
+if you haven't made one yet, you can visit:
+      file:///$cwd/subscription-payment.html
+
+and use the sandbox buyer account to make the payment.
+_PROFILEID_
+
+my $startdate = '1998-01-01T01:45:10.00Z';
+
+my $ts   = new Business::PayPal::API::TransactionSearch( %args );
+
+my $resp = $ts->TransactionSearch(StartDate => $startdate);
+
+use Data::Dumper;
+
+ok(scalar @{$resp} > 0, "Some transactions found");
+
+my($profileID, %possibleTransactionIDs);
+foreach my $record (@{$resp}) {
+  if ($record->{Type} =~ /Recurring/) {
+    if ($record->{Status} =~ /Completed/) {
+      $possibleTransactionIDs{$record->{TransactionID}} = $record;
+    } elsif ($record->{Status} =~ /Created/) {
+      $profileID = $record->{TransactionID};
+    }
+  }
+}
+ok(defined $profileID, "Subscription Payment Creation Record and ProfileID Found");
+ok(scalar(keys %possibleTransactionIDs) > 0, "Subscription Payment Transactions Found");
+
+$resp = $ts->TransactionSearch(StartDate => $startdate,
+                               ProfileID => $profileID);
+
+my $foundAtLeastOne = 0;
+foreach my $record (@{$resp}) {
+  # One of these will need to be in the possibleTransactionID list (i.e.,
+  # we're assuming that at least one payment has occured in this repeating).
+  if (defined $possibleTransactionIDs{$record->{TransactionID}}) {
+    $foundAtLeastOne = 1; last;
+  }
+}
+ok($foundAtLeastOne, "Found one payment transaction under the given Profile ID");

--- a/t/SubscriptionPayments.t
+++ b/t/SubscriptionPayments.t
@@ -1,6 +1,8 @@
 # -*- mode: cperl -*-
 use Test::More;
 use strict;
+use autodie qw(:all);
+
 if ( !$ENV{WPP_TEST} || !-f $ENV{WPP_TEST} ) {
     plan skip_all =>
         'No WPP_TEST env var set. Please see README to run tests';
@@ -30,8 +32,8 @@ This works, and seems to be correct, albeit odd.
 
 =cut
 
-open(SUBSCRIPTION_PAY_HTML, ">", "subscription-payment.html")
-  or die "unable to open subscription-payment.html: $!";
+open(SUBSCRIPTION_PAY_HTML, ">", "subscription-payment.html");
+
 print SUBSCRIPTION_PAY_HTML <<_SUBSCRIPTION_PAYMENT_DATA_
 <html>
 <body>
@@ -55,7 +57,7 @@ print SUBSCRIPTION_PAY_HTML <<_SUBSCRIPTION_PAYMENT_DATA_
 </html>
 _SUBSCRIPTION_PAYMENT_DATA_
   ;
-close(SUBSCRIPTION_PAY_HTML); die "unable to write subscription-payment.html: $!" if ($? != 0);
+close(SUBSCRIPTION_PAY_HTML);
 
 use Cwd; my $cwd = getcwd;
 


### PR DESCRIPTION
I noticed a long time ago that TransactionSearch doesn't allow searching on ProfileID, yet the PayPal SOAP API does indeed support that.

In this pull request, you'll find the simple addition of allowing such a search.  Also included, though, is a new test based on my own code that uses this ProfileID search.

You'll see here too that I've made a new way of doing these test that require user action in the sandbox: by creating a little HTML file on the filesystem with a form that will create the order.  I hope you find this reasonable.  Ideally, this would be fully mechanized with WWW:Mechanize or somesuch, but this is a useful first hack, I think.

Any feedback or changes you need to accept this upstream would be welcome!

Minor Note: the commits in 7198b854b9f32a9e28a4b8558b8550874c50af0b is identical to  840f87e4e6f8e944534451393db13bee9605f756 in pull request #4.  However, I think I've done this in a way such that if you merge either one first, it should merge cleanly.  Both pull requests depend on that change, and it's so minor, I figured it better simply to include it in both pull requests rather than make a separate pull request for such a minor change.

Finally, I hereby license my copyrights herein under the same license as Perl itself. :)