### PR TITLE
GetTransactionDetails: Properly extract Options from PaymentItemInfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ auth.txt
 blib
 perltidy.LOG
 pm_to_blib
+options-payment.html

--- a/Changes
+++ b/Changes
@@ -9,6 +9,8 @@ Revision history for Perl module Business::PayPal::API
     - Extract out more payer details from XML.
       (PayerName, NameSuffix, PayerCountry).
     - Fix https://rt.cpan.org/Public/Bug/Display.html?id=67386
+    - Options fields of GetTransactionDetails are now returned as a hash,
+      containing the actual options data, rather than array of empty strings.
 
 
 0.70 2012-11-13

--- a/auth.sample.3token
+++ b/auth.sample.3token
@@ -1,3 +1,4 @@
 Username  = test1_api.mydomain.tld
 Password  = XXXXXXXXXXXXXXXX
 Signature = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+SellerEmail = email-of-business-test-account@mydomain.tld

--- a/auth.sample.cert
+++ b/auth.sample.cert
@@ -2,3 +2,4 @@ Username = test1_api.mydomain.tld
 Password = myapipassword
 CertFile = /www/var/cert_key_pem.txt
 KeyFile  = /www/var/cert_key_pem.txt
+SellerEmail = email-of-business-test-account@mydomain.tld

--- a/lib/Business/PayPal/API/GetTransactionDetails.pm
+++ b/lib/Business/PayPal/API/GetTransactionDetails.pm
@@ -325,10 +325,12 @@ L<https://developer.paypal.com/en_US/pdf/PP_APIReference.pdf>
 =head1 AUTHOR
 
 Scot Wiersdorf E<lt>scott@perlcode.orgE<gt>
+Bradley M. Kuhn E<lt>bkuhn@ebb.orgE<gt>
 
 =head1 COPYRIGHT AND LICENSE
 
 Copyright (C) 2006 by Scott Wiersdorf
+Copyright (C) 2014, 2015 by Bradley M. Kuhn
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself, either Perl version 5.8.5 or,

--- a/lib/Business/PayPal/API/GetTransactionDetails.pm
+++ b/lib/Business/PayPal/API/GetTransactionDetails.pm
@@ -301,3 +301,13 @@ at your option, any later version of Perl 5 you may have available.
 
 
 =cut
+
+# Local Variables:
+#   Mode: CPerl
+#   indent-tabs-mode: nil
+#   cperl-indent-level: 4
+#   cperl-brace-offset: 0
+#   cperl-continued-brace-offset: 0
+#   cperl-label-offset: -4
+#   cperl-continued-statement-offset: 4
+# End:

--- a/t/API.pl
+++ b/t/API.pl
@@ -26,7 +26,7 @@ sub do_args {
 
     my @variables = qw( Username Password Signature Subject timeout
         CertFile KeyFile PKCS12File PKCS12Password
-        BuyerEmail
+        BuyerEmail SellerEmail
     );
 
     my %patterns = ();

--- a/t/OptionFields.t
+++ b/t/OptionFields.t
@@ -10,7 +10,7 @@ if ( !$ENV{WPP_TEST} || !-f $ENV{WPP_TEST} ) {
         'No WPP_TEST env var set. Please see README to run tests';
 }
 else {
-    plan tests => 6;
+    plan tests => 14;
 }
 
 use_ok( 'Business::PayPal::API::TransactionSearch' );
@@ -75,10 +75,14 @@ foreach my $record (@{$resp}) {
 like($detail{PaymentItems}[0]{Name}, qr/Field\s+Options/i, 'Found field options test transaction');
 like($detail{PII_Name}, qr/Field\s+Options/i, 'Found field options test transaction');
 
-foreach my $options ($detail{PaymentItems}[0]{Options}, $detail{PII_Options}) {
-    ok((scalar(@$options) == 2 and $options->[0] eq '' and $options->[0] eq ''),
-       "PaymentItems's Options has 2 elements with empty strings");
+foreach my $options ($detail{PaymentItems}[0]{Options}, $detail{PII_Options}[0]) {
+    ok(scalar(keys %$options) == 2, "The PaymentItems Options has 2 elements");
+    ok(defined $options->{firstOption}, "'firstOption' is present");
+    ok($options->{firstOption} eq 'Yes', "'firstOption' is selected as 'Yes'");
+    ok(defined $options->{size}, "'size' option is present");
+    ok($options->{size} eq "Large", "'size' option is selected as 'Large'");
 }
+
 # Local Variables:
 #   Mode: CPerl
 #   indent-tabs-mode: nil

--- a/t/OptionFields.t
+++ b/t/OptionFields.t
@@ -2,6 +2,7 @@
 # -*- mode: cperl -*-
 use Test::More;
 use strict;
+use Cwd;
 if ( !$ENV{WPP_TEST} || !-f $ENV{WPP_TEST} ) {
     plan skip_all =>
         'No WPP_TEST env var set. Please see README to run tests';
@@ -47,7 +48,7 @@ _OPTIONS_PAYMENT_DATA_
   ;
 close(OPTIONS_PAY_HTML); die "unable to write options-payment.html: $!" if ($? != 0);
 
-use Cwd; my $cwd = getcwd;
+my $cwd = getcwd;
 
 print STDERR <<"_OPTIONS_LINK_";
 Please note the next series of tests will not succeeed unless there is at

--- a/t/OptionFields.t
+++ b/t/OptionFields.t
@@ -7,7 +7,7 @@ if ( !$ENV{WPP_TEST} || !-f $ENV{WPP_TEST} ) {
         'No WPP_TEST env var set. Please see README to run tests';
 }
 else {
-    plan tests => 4;
+    plan tests => 6;
 }
 
 use_ok( 'Business::PayPal::API::TransactionSearch' );
@@ -73,4 +73,9 @@ foreach my $record (@{$resp}) {
 }
 like($detail{PaymentItems}[0]{Name}, qr/Field\s+Options/i, 'Found field options test transaction');
 like($detail{PII_Name}, qr/Field\s+Options/i, 'Found field options test transaction');
+
+foreach my $options ($detail{PaymentItems}[0]{Options}, $detail{PII_Options}) {
+  ok((scalar(@$options) == 2 and $options->[0] eq '' and $options->[0] eq ''),
+     "PaymentItems's Options has 2 elements with empty strings");
+}
 

--- a/t/OptionFields.t
+++ b/t/OptionFields.t
@@ -1,0 +1,76 @@
+# This file is part of Business:PayPal:API Module.   License: Same as Perl.  See its README for details.
+# -*- mode: cperl -*-
+use Test::More;
+use strict;
+if ( !$ENV{WPP_TEST} || !-f $ENV{WPP_TEST} ) {
+    plan skip_all =>
+        'No WPP_TEST env var set. Please see README to run tests';
+}
+else {
+    plan tests => 4;
+}
+
+use_ok( 'Business::PayPal::API::TransactionSearch' );
+use_ok( 'Business::PayPal::API::GetTransactionDetails' );
+
+#########################
+
+require 't/API.pl';
+
+my %args = do_args();
+
+=pod
+
+These tests verify the options work.
+
+=cut
+
+
+open(OPTIONS_PAY_HTML, ">", "options-payment.html")
+  or die "unable to open options-payment.html: $!";
+print OPTIONS_PAY_HTML <<_OPTIONS_PAYMENT_DATA_
+<html>
+<body>
+<form action="https://www.sandbox.paypal.com/cgi-bin/webscr" method="post" target="_top">
+   <input type="hidden" name="cmd" value="_xclick" />
+   <input type="hidden" name="business" value="$args{SellerEmail}" />
+   <input type="hidden" name="item_name" value="Field Options Tester" />
+   <input id="no_shipping" type="hidden" name="no_shipping" value="0" />
+   <input id="amount" type="text" name="amount" size="7" minimum="120" value="120" />
+   <input type="hidden" name="on1" value="firstOption" />
+   <input type="hidden" name="os1" value="Yes" />
+   <input type="hidden" name="on2" value="size"/>
+   <input name="os2" id="os2" value="Large"/>
+   <input type="image" border="0" name="submit" alt="Submit Field Tester with $120 payment">
+</form></body></html>
+_OPTIONS_PAYMENT_DATA_
+  ;
+close(OPTIONS_PAY_HTML); die "unable to write options-payment.html: $!" if ($? != 0);
+
+use Cwd; my $cwd = getcwd;
+
+print STDERR <<"_OPTIONS_LINK_";
+Please note the next series of tests will not succeeed unless there is at
+least one transaction that is part of a subscription payments in your business
+account.
+
+if you haven't made one yet, you can visit:
+      file://$cwd/options-payment.html
+
+and use the sandbox buyer account to make the payment.
+_OPTIONS_LINK_
+
+my $startdate = '1998-01-01T01:45:10.00Z';
+
+my $ts   = new Business::PayPal::API::TransactionSearch( %args );
+my $td   = new Business::PayPal::API::GetTransactionDetails( %args );
+
+my $resp = $ts->TransactionSearch(StartDate     => $startdate);
+my %detail;
+foreach my $record (@{$resp}) {
+  %detail = $td->GetTransactionDetails(TransactionID => $record->{TransactionID});
+  last if $detail{PII_Name} =~ /Field\s+Options/i;
+}
+like($detail{PaymentItems}[0]{Name}, qr/Field\s+Options/i, 'Found field options test transaction');
+like($detail{PII_Name}, qr/Field\s+Options/i, 'Found field options test transaction');
+

--- a/t/OptionFields.t
+++ b/t/OptionFields.t
@@ -2,7 +2,9 @@
 # -*- mode: cperl -*-
 use Test::More;
 use strict;
+use autodie qw(:all);
 use Cwd;
+
 if ( !$ENV{WPP_TEST} || !-f $ENV{WPP_TEST} ) {
     plan skip_all =>
         'No WPP_TEST env var set. Please see README to run tests';
@@ -26,9 +28,7 @@ These tests verify the options work.
 
 =cut
 
-
-open(OPTIONS_PAY_HTML, ">", "options-payment.html")
-  or die "unable to open options-payment.html: $!";
+open(OPTIONS_PAY_HTML, ">", "options-payment.html");
 print OPTIONS_PAY_HTML <<_OPTIONS_PAYMENT_DATA_
 <html>
 <body>
@@ -46,7 +46,7 @@ print OPTIONS_PAY_HTML <<_OPTIONS_PAYMENT_DATA_
 </form></body></html>
 _OPTIONS_PAYMENT_DATA_
   ;
-close(OPTIONS_PAY_HTML); die "unable to write options-payment.html: $!" if ($? != 0);
+close(OPTIONS_PAY_HTML);
 
 my $cwd = getcwd;
 

--- a/t/OptionFields.t
+++ b/t/OptionFields.t
@@ -69,14 +69,23 @@ my $td   = new Business::PayPal::API::GetTransactionDetails( %args );
 my $resp = $ts->TransactionSearch(StartDate     => $startdate);
 my %detail;
 foreach my $record (@{$resp}) {
-  %detail = $td->GetTransactionDetails(TransactionID => $record->{TransactionID});
-  last if $detail{PII_Name} =~ /Field\s+Options/i;
+    %detail = $td->GetTransactionDetails(TransactionID => $record->{TransactionID});
+    last if $detail{PII_Name} =~ /Field\s+Options/i;
 }
 like($detail{PaymentItems}[0]{Name}, qr/Field\s+Options/i, 'Found field options test transaction');
 like($detail{PII_Name}, qr/Field\s+Options/i, 'Found field options test transaction');
 
 foreach my $options ($detail{PaymentItems}[0]{Options}, $detail{PII_Options}) {
-  ok((scalar(@$options) == 2 and $options->[0] eq '' and $options->[0] eq ''),
-     "PaymentItems's Options has 2 elements with empty strings");
+    ok((scalar(@$options) == 2 and $options->[0] eq '' and $options->[0] eq ''),
+       "PaymentItems's Options has 2 elements with empty strings");
 }
+# Local Variables:
+#   Mode: CPerl
+#   indent-tabs-mode: nil
+#   cperl-indent-level: 4
+#   cperl-brace-offset: 0
+#   cperl-continued-brace-offset: 0
+#   cperl-label-offset: -4
+#   cperl-continued-statement-offset: 4
+# End:
 


### PR DESCRIPTION
I recently attempted to make use of the Options fields as part of PaymentItemInfo and discovered that the API didn't provide the actual data regarding the Options via its interface.

This pull request corrects that bug in the API.  It does make a minor API-user-visible change that I think is appropriate given the nature of the bug.  I've fully documented that in the Changes file and in the API documentation.

Minor Note: the commits in 840f87e4e6f8e944534451393db13bee9605f756 is identical to  7198b854b9f32a9e28a4b8558b8550874c50af0b in pull request #3.  However, I think I've done this in a way such that if you merge either one first, it should merge cleanly.  Both pull requests depend on that change, and it's so minor, I figured it better simply to include it in both pull requests rather than make a separate pull request for such a minor change.

Finally, I hereby license my copyrights herein under the same license as Perl itself. :)