### PR TITLE
GetTransactionDetails: Properly extract Options from PaymentItemInfo; also, document and test Options clearly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ blib
 perltidy.LOG
 pm_to_blib
 subscription-payment.html
+options-payment.html

--- a/Changes
+++ b/Changes
@@ -9,6 +9,8 @@ Revision history for Perl module Business::PayPal::API
     - Extract out more payer details from XML.
       (PayerName, NameSuffix, PayerCountry).
     - Fix https://rt.cpan.org/Public/Bug/Display.html?id=67386
+    - Options fields of GetTransactionDetails are now returned as a hash,
+      containing the actual options data, rather than array of empty strings.
 
 
 0.70 2012-11-13

--- a/lib/Business/PayPal/API/GetTransactionDetails.pm
+++ b/lib/Business/PayPal/API/GetTransactionDetails.pm
@@ -325,10 +325,12 @@ L<https://developer.paypal.com/en_US/pdf/PP_APIReference.pdf>
 =head1 AUTHOR
 
 Scot Wiersdorf E<lt>scott@perlcode.orgE<gt>
+Bradley M. Kuhn E<lt>bkuhn@ebb.orgE<gt>
 
 =head1 COPYRIGHT AND LICENSE
 
 Copyright (C) 2006 by Scott Wiersdorf
+Copyright (C) 2014, 2015 by Bradley M. Kuhn
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself, either Perl version 5.8.5 or,

--- a/lib/Business/PayPal/API/GetTransactionDetails.pm
+++ b/lib/Business/PayPal/API/GetTransactionDetails.pm
@@ -291,7 +291,8 @@ records:
                       Number   => '...',
                       Quantity => '...',
                       Amount   => '...',
-                      Options  => { 'key' => 'value', ... },
+                      Options  => { 'key0' => 'value0',
+                                    'key1' => 'value1' },
                     },
                     { SalesTax => ..., etc. 
                     } ]
@@ -308,6 +309,16 @@ Example:
           print "Option: $optionname is " . $item->{Options}{$optionname} . "\n";
       }
   }
+
+=head2 PaymentItem Options Limitations
+
+Note, BTW, that PayPal has a limitation such that each PaymentItem can
+contain only two Options.  See:
+   L<https://www.paypal.com/cgi-bin/webscr?cmd=p/xcl/rec/options-help-outside>
+   L<https://developer.paypal.com/webapps/developer/docs/classic/paypal-payments-standard/integration-guide/Appx_websitestandard_htmlvariables/>
+
+This hack may be of interest if you want to sneak in four options:
+   L<https://ppmts.custhelp.com/app/answers/detail/a_id/298/kw/soap%20gettransactiondetails%20option>
 
 =head2 ERROR HANDLING
 

--- a/lib/Business/PayPal/API/GetTransactionDetails.pm
+++ b/lib/Business/PayPal/API/GetTransactionDetails.pm
@@ -301,3 +301,13 @@ at your option, any later version of Perl 5 you may have available.
 
 
 =cut
+
+# Local Variables:
+#   Mode: CPerl
+#   indent-tabs-mode: nil
+#   cperl-indent-level: 4
+#   cperl-brace-offset: 0
+#   cperl-continued-brace-offset: 0
+#   cperl-label-offset: -4
+#   cperl-continued-statement-offset: 4
+# End:

--- a/t/OptionFields.t
+++ b/t/OptionFields.t
@@ -56,7 +56,7 @@ if (defined $itemName) {
    <input type="hidden" name="os1" value="Yes" />
    <input type="hidden" name="on2" value="size"/>
    <input name="os2" id="os2" value="Large"/>
-   <input type="image" border="0" name="submit" alt="Submit Field Tester with $120 payment">
+   <input type="image" border="0" name="submit" alt="Submit Field Tester, $itemName, with \$120 payment">
 </form></body></html>
 _OPTIONS_PAYMENT_DATA_
         ;

--- a/t/OptionFields.t
+++ b/t/OptionFields.t
@@ -10,7 +10,7 @@ if ( !$ENV{WPP_TEST} || !-f $ENV{WPP_TEST} ) {
         'No WPP_TEST env var set. Please see README to run tests';
 }
 else {
-    plan tests => 6;
+    plan tests => 14;
 }
 
 use_ok( 'Business::PayPal::API::TransactionSearch' );
@@ -75,10 +75,14 @@ foreach my $record (@{$resp}) {
 like($detail{PaymentItems}[0]{Name}, qr/Field\s+Options/i, 'Found field options test transaction');
 like($detail{PII_Name}, qr/Field\s+Options/i, 'Found field options test transaction');
 
-foreach my $options ($detail{PaymentItems}[0]{Options}, $detail{PII_Options}) {
-    ok((scalar(@$options) == 2 and $options->[0] eq '' and $options->[0] eq ''),
-       "PaymentItems's Options has 2 elements with empty strings");
+foreach my $options ($detail{PaymentItems}[0]{Options}, $detail{PII_Options}[0]) {
+    ok(scalar(keys %$options) == 2, "The PaymentItems Options has 2 elements");
+    ok(defined $options->{firstOption}, "'firstOption' is present");
+    ok($options->{firstOption} eq 'Yes', "'firstOption' is selected as 'Yes'");
+    ok(defined $options->{size}, "'size' option is present");
+    ok($options->{size} eq "Large", "'size' option is selected as 'Large'");
 }
+
 # Local Variables:
 #   Mode: CPerl
 #   indent-tabs-mode: nil

--- a/t/OptionFields.t
+++ b/t/OptionFields.t
@@ -2,6 +2,7 @@
 # -*- mode: cperl -*-
 use Test::More;
 use strict;
+use Cwd;
 if ( !$ENV{WPP_TEST} || !-f $ENV{WPP_TEST} ) {
     plan skip_all =>
         'No WPP_TEST env var set. Please see README to run tests';
@@ -47,7 +48,7 @@ _OPTIONS_PAYMENT_DATA_
   ;
 close(OPTIONS_PAY_HTML); die "unable to write options-payment.html: $!" if ($? != 0);
 
-use Cwd; my $cwd = getcwd;
+my $cwd = getcwd;
 
 print STDERR <<"_OPTIONS_LINK_";
 Please note the next series of tests will not succeeed unless there is at

--- a/t/OptionFields.t
+++ b/t/OptionFields.t
@@ -7,7 +7,7 @@ if ( !$ENV{WPP_TEST} || !-f $ENV{WPP_TEST} ) {
         'No WPP_TEST env var set. Please see README to run tests';
 }
 else {
-    plan tests => 4;
+    plan tests => 6;
 }
 
 use_ok( 'Business::PayPal::API::TransactionSearch' );
@@ -73,4 +73,9 @@ foreach my $record (@{$resp}) {
 }
 like($detail{PaymentItems}[0]{Name}, qr/Field\s+Options/i, 'Found field options test transaction');
 like($detail{PII_Name}, qr/Field\s+Options/i, 'Found field options test transaction');
+
+foreach my $options ($detail{PaymentItems}[0]{Options}, $detail{PII_Options}) {
+  ok((scalar(@$options) == 2 and $options->[0] eq '' and $options->[0] eq ''),
+     "PaymentItems's Options has 2 elements with empty strings");
+}
 

--- a/t/OptionFields.t
+++ b/t/OptionFields.t
@@ -87,6 +87,7 @@ my %detail;
 foreach my $record (@{$resp}) {
     %detail = $td->GetTransactionDetails(TransactionID => $record->{TransactionID});
     last if $detail{PII_Name} =~ /$itemName/;
+    %detail = {};
 }
 like($detail{PaymentItems}[0]{Name}, qr/$itemName/, 'Found field options test transaction');
 like($detail{PII_Name}, qr/$itemName/, 'Found field options test transaction');

--- a/t/OptionFields.t
+++ b/t/OptionFields.t
@@ -1,0 +1,76 @@
+# This file is part of Business:PayPal:API Module.   License: Same as Perl.  See its README for details.
+# -*- mode: cperl -*-
+use Test::More;
+use strict;
+if ( !$ENV{WPP_TEST} || !-f $ENV{WPP_TEST} ) {
+    plan skip_all =>
+        'No WPP_TEST env var set. Please see README to run tests';
+}
+else {
+    plan tests => 4;
+}
+
+use_ok( 'Business::PayPal::API::TransactionSearch' );
+use_ok( 'Business::PayPal::API::GetTransactionDetails' );
+
+#########################
+
+require 't/API.pl';
+
+my %args = do_args();
+
+=pod
+
+These tests verify the options work.
+
+=cut
+
+
+open(OPTIONS_PAY_HTML, ">", "options-payment.html")
+  or die "unable to open options-payment.html: $!";
+print OPTIONS_PAY_HTML <<_OPTIONS_PAYMENT_DATA_
+<html>
+<body>
+<form action="https://www.sandbox.paypal.com/cgi-bin/webscr" method="post" target="_top">
+   <input type="hidden" name="cmd" value="_xclick" />
+   <input type="hidden" name="business" value="$args{SellerEmail}" />
+   <input type="hidden" name="item_name" value="Field Options Tester" />
+   <input id="no_shipping" type="hidden" name="no_shipping" value="0" />
+   <input id="amount" type="text" name="amount" size="7" minimum="120" value="120" />
+   <input type="hidden" name="on1" value="firstOption" />
+   <input type="hidden" name="os1" value="Yes" />
+   <input type="hidden" name="on2" value="size"/>
+   <input name="os2" id="os2" value="Large"/>
+   <input type="image" border="0" name="submit" alt="Submit Field Tester with $120 payment">
+</form></body></html>
+_OPTIONS_PAYMENT_DATA_
+  ;
+close(OPTIONS_PAY_HTML); die "unable to write options-payment.html: $!" if ($? != 0);
+
+use Cwd; my $cwd = getcwd;
+
+print STDERR <<"_OPTIONS_LINK_";
+Please note the next series of tests will not succeeed unless there is at
+least one transaction that is part of a subscription payments in your business
+account.
+
+if you haven't made one yet, you can visit:
+      file://$cwd/options-payment.html
+
+and use the sandbox buyer account to make the payment.
+_OPTIONS_LINK_
+
+my $startdate = '1998-01-01T01:45:10.00Z';
+
+my $ts   = new Business::PayPal::API::TransactionSearch( %args );
+my $td   = new Business::PayPal::API::GetTransactionDetails( %args );
+
+my $resp = $ts->TransactionSearch(StartDate     => $startdate);
+my %detail;
+foreach my $record (@{$resp}) {
+  %detail = $td->GetTransactionDetails(TransactionID => $record->{TransactionID});
+  last if $detail{PII_Name} =~ /Field\s+Options/i;
+}
+like($detail{PaymentItems}[0]{Name}, qr/Field\s+Options/i, 'Found field options test transaction');
+like($detail{PII_Name}, qr/Field\s+Options/i, 'Found field options test transaction');
+

--- a/t/OptionFields.t
+++ b/t/OptionFields.t
@@ -2,7 +2,9 @@
 # -*- mode: cperl -*-
 use Test::More;
 use strict;
+use autodie qw(:all);
 use Cwd;
+
 if ( !$ENV{WPP_TEST} || !-f $ENV{WPP_TEST} ) {
     plan skip_all =>
         'No WPP_TEST env var set. Please see README to run tests';
@@ -26,9 +28,7 @@ These tests verify the options work.
 
 =cut
 
-
-open(OPTIONS_PAY_HTML, ">", "options-payment.html")
-  or die "unable to open options-payment.html: $!";
+open(OPTIONS_PAY_HTML, ">", "options-payment.html");
 print OPTIONS_PAY_HTML <<_OPTIONS_PAYMENT_DATA_
 <html>
 <body>
@@ -46,7 +46,7 @@ print OPTIONS_PAY_HTML <<_OPTIONS_PAYMENT_DATA_
 </form></body></html>
 _OPTIONS_PAYMENT_DATA_
   ;
-close(OPTIONS_PAY_HTML); die "unable to write options-payment.html: $!" if ($? != 0);
+close(OPTIONS_PAY_HTML);
 
 my $cwd = getcwd;
 

--- a/t/OptionFields.t
+++ b/t/OptionFields.t
@@ -52,10 +52,10 @@ if (defined $itemName) {
    <input type="hidden" name="item_name" value="Field Options Tester: $itemName" />
    <input id="no_shipping" type="hidden" name="no_shipping" value="0" />
    <input id="amount" type="text" name="amount" size="7" minimum="120" value="120" />
-   <input type="hidden" name="on1" value="firstOption" />
-   <input type="hidden" name="os1" value="Yes" />
-   <input type="hidden" name="on2" value="size"/>
-   <input name="os2" id="os2" value="Large"/>
+   <input type="hidden" name="on0" value="firstOption" />
+   <input type="hidden" name="os0" value="Yes" />
+   <input type="hidden" name="on1" value="size"/>
+   <input name="os1" id="os1" value="Large"/>
    <input type="image" border="0" name="submit" alt="Submit Field Tester, $itemName, with \$120 payment">
 </form></body></html>
 _OPTIONS_PAYMENT_DATA_

--- a/t/OptionFields.t
+++ b/t/OptionFields.t
@@ -69,14 +69,23 @@ my $td   = new Business::PayPal::API::GetTransactionDetails( %args );
 my $resp = $ts->TransactionSearch(StartDate     => $startdate);
 my %detail;
 foreach my $record (@{$resp}) {
-  %detail = $td->GetTransactionDetails(TransactionID => $record->{TransactionID});
-  last if $detail{PII_Name} =~ /Field\s+Options/i;
+    %detail = $td->GetTransactionDetails(TransactionID => $record->{TransactionID});
+    last if $detail{PII_Name} =~ /Field\s+Options/i;
 }
 like($detail{PaymentItems}[0]{Name}, qr/Field\s+Options/i, 'Found field options test transaction');
 like($detail{PII_Name}, qr/Field\s+Options/i, 'Found field options test transaction');
 
 foreach my $options ($detail{PaymentItems}[0]{Options}, $detail{PII_Options}) {
-  ok((scalar(@$options) == 2 and $options->[0] eq '' and $options->[0] eq ''),
-     "PaymentItems's Options has 2 elements with empty strings");
+    ok((scalar(@$options) == 2 and $options->[0] eq '' and $options->[0] eq ''),
+       "PaymentItems's Options has 2 elements with empty strings");
 }
+# Local Variables:
+#   Mode: CPerl
+#   indent-tabs-mode: nil
+#   cperl-indent-level: 4
+#   cperl-brace-offset: 0
+#   cperl-continued-brace-offset: 0
+#   cperl-label-offset: -4
+#   cperl-continued-statement-offset: 4
+# End:
 

--- a/t/OptionFields.t
+++ b/t/OptionFields.t
@@ -56,6 +56,8 @@ if (defined $itemName) {
    <input type="hidden" name="os0" value="Yes" />
    <input type="hidden" name="on1" value="size"/>
    <input name="os1" id="os1" value="Large"/>
+   <input type="hidden" name="on2" value="lostOption"/>
+   <input name="os2" id="os2" value="NeverToBeSeen"/>
    <input type="image" border="0" name="submit" alt="Submit Field Tester, $itemName, with \$120 payment">
 </form></body></html>
 _OPTIONS_PAYMENT_DATA_
@@ -91,6 +93,25 @@ foreach my $record (@{$resp}) {
 }
 like($detail{PaymentItems}[0]{Name}, qr/$itemName/, 'Found field options test transaction');
 like($detail{PII_Name}, qr/$itemName/, 'Found field options test transaction');
+
+=pod
+
+Note that the tests below all pass when only two Options are found, even
+though our HTML file above passes through I<three> options.
+
+Yet, if you look at the transaction details in the PayPal sandbox web
+interface, you'll see that all three Options are present in its record
+description.  Thus, Options beyond the first two appears only partially
+supported by PayPal.
+
+Thus, our tests verify this fact by submitting three of these fields, but
+expecting only the first two back.
+
+More details on this can be found in the
+L<Business:PayPal:API:GetTransactionDetails/"PaymentItem Options Limitations">
+documentation.
+
+=cut
 
 foreach my $options ($detail{PaymentItems}[0]{Options}, $detail{PII_Options}[0]) {
     ok(scalar(keys %$options) == 2, "The PaymentItems Options has 2 elements");


### PR DESCRIPTION
*This pull request is an updated version of Pull Request #4.  Pull Request #4 was automatically closed by GitHub because I rebased the branch.  (Why can't GitHub support that?)  Anyway, I also added a few new things as well.*

I recently attempted to make use of the Options fields as part of PaymentItemInfo and discovered that the API didn't provide the actual data regarding the Options via its interface.

This pull request corrects that bug in the API. It does make a minor API-user-visible change that I think is appropriate given the nature of the bug. I've fully documented that in the Changes file and in the API documentation.

Finally, I hereby license my copyrights herein under the same license as Perl itself. :)