### PR TITLE
Set the types of the Address hashref in SetExpressCheckout

### DIFF
--- a/lib/Business/PayPal/API/ExpressCheckout.pm
+++ b/lib/Business/PayPal/API/ExpressCheckout.pm
@@ -77,6 +77,29 @@ sub SetExpressCheckout {
                 ->attr(
                 { currencyID => $currencyID, xmlns => $self->C_xmlns_ebay } );
         }
+        elsif ( $field eq 'Address' ) {
+            my $address = $args{$field};
+            my %address_types = (
+                                 Name            => 'xs:string',
+                                 Street1         => 'xs:string',
+                                 Street2         => 'xs:string',
+                                 CityName        => 'xs:string',
+                                 StateOrProvince => 'xs:string',
+                                 Country         => 'xs:string',
+                                 PostalCode      => 'xs:string',
+                                );
+            my @address;
+            foreach my $k (keys %address_types) {
+                if (defined $address->{$k}) {
+                    push @address, SOAP::Data->name( $k => $address->{$k} )->type($address_types{$k});
+                }
+            }
+            if (@address) {
+                push @secrd, SOAP::Data->name($field => \SOAP::Data->value ( @address )
+                                              ->type( $types{$field} )
+                                              ->attr( { xmlns => $self->C_xmlns_ebay } ) );
+            }
+        }
         else {
             push @secrd,
                 SOAP::Data->name( $field => $args{$field} )


### PR DESCRIPTION
It looks like the SetExpressCheckout Address hashref was not enforcing the types, defaulting to base64 binary, e.g.

<CityName xsi:type="xsd:base64Binary">UPzfYQ==</CityName>

Apparently (but I could be wrong) this has not a problem since lately, when people started seeing in the paypal review page the verbatim base64 when the string has characters out of the ascii range.

This pull request seems to fix the problem, doing a similar thing as in the DoExpressCheckoutPayment sub.

Thanks in advance.
