### PR TITLE
- Updated SEE ALSO links.

### DIFF
--- a/lib/Business/PayPal/API.pm
+++ b/lib/Business/PayPal/API.pm
@@ -810,9 +810,8 @@ calls.
 
 =head1 SEE ALSO
 
-L<SOAP::Lite>, L<https://www.paypal.com/IntegrationCenter/ic_pro_home.html>,
-L<https://www.paypal.com/IntegrationCenter/ic_expresscheckout.html>,
-L<https://www.sandbox.paypal.com/en_US/pdf/PP_Sandbox_UserGuide.pdf>,
-L<https://developer.paypal.com/en_US/pdf/PP_APIReference.pdf>
+L<SOAP::Lite>,
+L<PayPal User Guide|https://developer.paypal.com/webapps/developer/docs/classic/products>,
+L<PayPal API Reference|https://developer.paypal.com/webapps/developer/docs/api/overview>
 
 =cut


### PR DESCRIPTION
Hi Olaf,

Can you please review the following changes:

The following links in the section "SEE ALSO" no longer exists. It simply redirects to https://developer.paypal.com

- https://www.paypal.com/IntegrationCenter/ic_pro_home.html
- https://www.paypal.com/IntegrationCenter/ic_expresscheckout.html

And the link below no longer exists

- https://www.sandbox.paypal.com/en_US/pdf/PP_Sandbox_UserGuide.pdf

The new location is as below

- https://developer.paypal.com/webapps/developer/docs/classic/products

Last but not the least API Reference link has also changed as below

- https://developer.paypal.com/webapps/developer/docs/api/overview

Many Thanks.

Best Regards,
Mohammad S Anwar