### PR TITLE
Field map typo fix (Salutation)

### DIFF
--- a/lib/Business/PayPal/API/ExpressCheckout.pm
+++ b/lib/Business/PayPal/API/ExpressCheckout.pm
@@ -182,7 +182,7 @@ sub GetExpressCheckoutDetails {
             Payer           => 'PayerInfo/Payer',
             PayerID         => 'PayerInfo/PayerID',
             PayerStatus     => 'PayerInfo/PayerStatus',
-            Salutation      => 'PayerInfo/PayerName/Saluation',
+            Salutation      => 'PayerInfo/PayerName/Salutation',
             FirstName       => 'PayerInfo/PayerName/FirstName',
             MiddleName      => 'PayerInfo/PayerName/MiddleName',
             LastName        => 'PayerInfo/PayerName/LastName',


### PR DESCRIPTION
There is just a minor field map typo -- Salutation vs Saluation